### PR TITLE
Fixed bug of null

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -275,13 +275,15 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
             }
         }
         for (CodegenParameter p : op.allParams) {
-            if (p == lastRequired) {
-                p.vendorExtensions.put("x-codegen-hasMoreRequired", false);
-            } else if (p == lastOptional) {
-                p.vendorExtensions.put("x-codegen-hasMoreOptional", false);
-            } else {
-                p.vendorExtensions.put("x-codegen-hasMoreRequired", true);
-                p.vendorExtensions.put("x-codegen-hasMoreOptional", true);
+            if (p != null) {
+                if (p == lastRequired) {
+                    p.vendorExtensions.put("x-codegen-hasMoreRequired", false);
+                } else if (p == lastOptional) {
+                    p.vendorExtensions.put("x-codegen-hasMoreOptional", false);
+                } else {
+                    p.vendorExtensions.put("x-codegen-hasMoreRequired", true);
+                    p.vendorExtensions.put("x-codegen-hasMoreOptional", true);
+                }
             }
         }
         op.vendorExtensions.put("x-codegen-hasRequiredParams", lastRequired != null);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

